### PR TITLE
Set up Cursor Cloud dev environment (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+Weather Widget Editor — an npm-workspaces monorepo. See `README.md` for the product overview, API reference, and standard commands.
+
+## Cursor Cloud specific instructions
+
+### Services
+
+| Workspace | Role | Dev command | Dev URL |
+|-----------|------|-------------|---------|
+| `packages/shared` | Shared types + validation (built to `dist/`, consumed by every other workspace) | n/a (build only, see below) | — |
+| `packages/api` | Express 5 REST API (`tsx watch`) | `npm run dev -w @weather-widget/api` | http://localhost:9090 |
+| `apps/editor` | Vite + React 19 editor UI (proxies `/api` and `/embed` to `:9090`) | `npm run dev -w @weather-widget/editor` | http://localhost:5173 |
+| `apps/embed` | Standalone embeddable widget bundle (`vite build --watch`) | `npm run dev -w @weather-widget/embed` | served at `/embed/widget.js` |
+
+Run everything at once with `npm run dev` (starts `api` + `editor` only — not `embed`). Lint/test/build commands are in the root and workspace `package.json` files.
+
+### Non-obvious gotchas
+
+- **Build `@weather-widget/shared` before running dev servers or tests.** All workspaces import it via its package `exports`, which point only at `packages/shared/dist/`. `dist/` is git-ignored, so on a fresh checkout you must run `npm run build -w @weather-widget/shared` once, or `npm run dev`/`npm test` will fail to resolve `@weather-widget/shared`. The full `npm run build` also builds it first.
+- **Lint = typecheck.** There is no ESLint config; the "lint" gate is TypeScript. `npm run build -w @weather-widget/editor` runs `tsc --noEmit`, and each package's `build` runs `tsc`.
+- **`OPENWEATHER_API_KEY` is required for live weather only.** Copy `.env.example` to `.env`. The `/api/weather` route (and the editor's "Get widget" preview and the embed widget) call OpenWeatherMap and return a 502 `"OPENWEATHER_API_KEY is not configured"` without a valid key. Health check and embed-snippet generation (`/api/widgets/snippet`) work without a key.
+- **Editor "Get widget" needs both a key and browser geolocation.** `App.tsx` runs `createSnippet` and `fetchWeather` together via `Promise.all`, so a failed weather fetch (missing key) prevents the snippet from rendering in the UI even though snippet generation itself succeeds. The form stays disabled until the browser grants geolocation.
+- **`legacy/` is archived** (2016 Gulp/Bower/jQuery). Do not build or run it.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up and verifies the development environment for the Weather Widget Editor monorepo, and documents durable startup notes for future cloud agents in a new `AGENTS.md`.

No application code was changed — only environment setup + documentation.

## Environment setup

- Update script: `npm install` (installs all npm-workspace deps).
- Added `AGENTS.md` `## Cursor Cloud specific instructions` capturing the non-obvious gotchas found during setup:
  - `@weather-widget/shared` must be built (`npm run build -w @weather-widget/shared`) before `dev`/`test` because workspaces import it from git-ignored `dist/`.
  - "Lint" is TypeScript typecheck (no ESLint); each `build` runs `tsc`.
  - `OPENWEATHER_API_KEY` is only needed for live weather; snippet generation / health work without it.
  - Editor "Get widget" needs both a key and browser geolocation (`Promise.all` couples snippet + weather).

## Verification

- `npm test` → 7 tests pass (shared + api).
- `npm run build` → all 4 workspaces build (incl. editor `tsc --noEmit`).
- `npm run dev` → API on `:9090`, editor on `:5173`.
- Hello-world action: generated an embed snippet through the running app (Vite proxy → Express).

[Editor loaded](https://cursor.com/agents/bc-3ea56f1a-8dce-4c08-a2ec-6b28534a8cd1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Feditor_loaded.webp)
[Editor form filled](https://cursor.com/agents/bc-3ea56f1a-8dce-4c08-a2ec-6b28534a8cd1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Feditor_form_filled.webp)

Live weather preview in the browser additionally requires a valid `OPENWEATHER_API_KEY` secret.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ea56f1a-8dce-4c08-a2ec-6b28534a8cd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ea56f1a-8dce-4c08-a2ec-6b28534a8cd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

