### PR TITLE
Add Render deployment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 OPENWEATHER_API_KEY=your_openweather_api_key_here
 PORT=9090
+# Optional locally; on Render, RENDER_EXTERNAL_URL is used automatically.
 PUBLIC_URL=http://localhost:9090

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -7,6 +7,9 @@ dotenv.config({ path: path.join(repoRoot, '.env') });
 
 export const config = {
   port: Number(process.env.PORT ?? 9090),
-  publicUrl: process.env.PUBLIC_URL ?? `http://localhost:${process.env.PORT ?? 9090}`,
+  publicUrl:
+    process.env.PUBLIC_URL ??
+    process.env.RENDER_EXTERNAL_URL ??
+    `http://localhost:${process.env.PORT ?? 9090}`,
   openWeatherApiKey: process.env.OPENWEATHER_API_KEY ?? '',
 };

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,15 @@
+services:
+  - type: web
+    name: weather-widget-editor
+    runtime: node
+    plan: free
+    region: oregon
+    branch: master
+    buildCommand: npm install && npm run build
+    startCommand: npm start
+    healthCheckPath: /api/health
+    envVars:
+      - key: NODE_VERSION
+        value: "20"
+      - key: OPENWEATHER_API_KEY
+        sync: false


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds everything needed to deploy the Weather Widget Editor to Render as a single Node web service.

## Changes

- **`render.yaml`** — Blueprint defining one free-tier web service that builds the monorepo and runs `npm start`
- **`packages/api/src/config.ts`** — Uses Render's `RENDER_EXTERNAL_URL` so embed snippets get the correct public URL without manual `PUBLIC_URL` configuration
- **`.env.example`** — Notes that `PUBLIC_URL` is optional on Render

## Deploy steps

1. Merge this PR to `master`
2. Open the [Render Blueprint deeplink](https://dashboard.render.com/blueprint/new?repo=https://github.com/awongCM/weather-widget-editor)
3. Connect your GitHub account if prompted
4. Set `OPENWEATHER_API_KEY` (marked `sync: false` in the Blueprint)
5. Click **Apply** to deploy

The service will be available at `https://weather-widget-editor.onrender.com` (or similar). Health check: `/api/health`.

## Notes

- Single web service serves the React editor, API, and embed assets
- No database required
- Free tier spins down after 15 minutes of inactivity
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5903-6584-7916-b808-ecc3ed2e42d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5903-6584-7916-b808-ecc3ed2e42d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

